### PR TITLE
Ignore automatic modules from CheckExportedPackages check

### DIFF
--- a/conformity/src/main/java/org/creek/internal/test/conformity/check/ExportedPackagesCheck.java
+++ b/conformity/src/main/java/org/creek/internal/test/conformity/check/ExportedPackagesCheck.java
@@ -45,6 +45,11 @@ public final class ExportedPackagesCheck implements CheckRunner {
     @Override
     public void check(final CheckTarget target) {
         final Module moduleUnderTest = target.moduleUnderTest();
+        if (moduleUnderTest.getDescriptor().isAutomatic()) {
+            // Do not test automatic modules, as everything is exposed.
+            // The fact a module is automatic will be picked up by CheckModule
+            return;
+        }
 
         checkApiPackagesExported(moduleUnderTest);
         checkNonApiPackagesNotExported(moduleUnderTest);

--- a/conformity/src/test/java/org/creek/internal/test/conformity/DefaultConformityTesterTest.java
+++ b/conformity/src/test/java/org/creek/internal/test/conformity/DefaultConformityTesterTest.java
@@ -58,9 +58,7 @@ class DefaultConformityTesterTest {
     @Test
     void shouldDetectUnnamedModule() {
         // Given:
-        final ConformityTester tester =
-                ConformityTester.builder(EqualsTester.class)
-                        .withDisabled("Not testing this one", CheckExportedPackages.builder());
+        final ConformityTester tester = ConformityTester.builder(EqualsTester.class);
 
         // When:
         final Error e = assertThrows(AssertionError.class, tester::check);
@@ -78,7 +76,7 @@ class DefaultConformityTesterTest {
         final ConformityTester tester =
                 ConformityTester.builder(ConformityTester.class)
                         .withCustom(
-                                "to allow testing",
+                                "to test customising",
                                 CheckExportedPackages.builder()
                                         .excludedPackages(NotExported.class.getPackageName()));
 
@@ -93,8 +91,7 @@ class DefaultConformityTesterTest {
         // Given:
         final ConformityTester tester =
                 ConformityTester.builder(EqualsTester.class)
-                        .withDisabled("To allow testing!", CheckModule.builder())
-                        .withDisabled("To allow testing!", CheckExportedPackages.builder());
+                        .withDisabled("To allow testing!", CheckModule.builder());
 
         // When:
         tester.check();

--- a/conformity/src/test/java/org/creek/internal/test/conformity/check/ExportedPackagesCheckTest.java
+++ b/conformity/src/test/java/org/creek/internal/test/conformity/check/ExportedPackagesCheckTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import java.lang.module.ModuleDescriptor;
 import java.util.Arrays;
 import java.util.Set;
 import org.creek.api.test.conformity.test.types.bad.NotExported;
@@ -40,6 +41,7 @@ class ExportedPackagesCheckTest {
 
     @Mock private CheckTarget ctx;
     @Mock private Module moduleUnderTest;
+    @Mock private ModuleDescriptor descriptor;
     private CheckRunner check;
 
     @BeforeEach
@@ -48,6 +50,7 @@ class ExportedPackagesCheckTest {
 
         when(ctx.moduleUnderTest()).thenReturn(moduleUnderTest);
         when(moduleUnderTest.getName()).thenReturn("Bob");
+        when(moduleUnderTest.getDescriptor()).thenReturn(descriptor);
     }
 
     @Test
@@ -116,6 +119,18 @@ class ExportedPackagesCheckTest {
                                 + "\torg.creek.internal.b"
                                 + System.lineSeparator()
                                 + "]"));
+    }
+
+    @Test
+    void shouldIgnoreAutomaticModules() {
+        // Given:
+        when(descriptor.isAutomatic()).thenReturn(true);
+        givenPackages("org.creek.api.a");
+
+        // When:
+        check.check(ctx);
+
+        // Then: did not throw.
     }
 
     @Test


### PR DESCRIPTION
as automatic modules export all their packages.  So a creek module that is an automatic module will always fail this test. However, given its already failed the `CheckModule` test, this is superfluous.
