### PR TITLE
Ignore unnamed modules from CheckExportedPackages check

### DIFF
--- a/conformity/src/main/java/org/creek/internal/test/conformity/check/ExportedPackagesCheck.java
+++ b/conformity/src/main/java/org/creek/internal/test/conformity/check/ExportedPackagesCheck.java
@@ -45,9 +45,9 @@ public final class ExportedPackagesCheck implements CheckRunner {
     @Override
     public void check(final CheckTarget target) {
         final Module moduleUnderTest = target.moduleUnderTest();
-        if (moduleUnderTest.getDescriptor().isAutomatic()) {
-            // Do not test automatic modules, as everything is exposed.
-            // The fact a module is automatic will be picked up by CheckModule
+        if (!moduleUnderTest.isNamed() || moduleUnderTest.getDescriptor().isAutomatic()) {
+            // Do not test unnamed/automatic modules, as everything is exposed.
+            // The fact a module is unnamed/automatic will be picked up by CheckModule
             return;
         }
 

--- a/conformity/src/test/java/org/creek/internal/test/conformity/check/ExportedPackagesCheckTest.java
+++ b/conformity/src/test/java/org/creek/internal/test/conformity/check/ExportedPackagesCheckTest.java
@@ -49,6 +49,7 @@ class ExportedPackagesCheckTest {
         check = new ExportedPackagesCheck(new ExportedPackagesCheck.Options());
 
         when(ctx.moduleUnderTest()).thenReturn(moduleUnderTest);
+        when(moduleUnderTest.isNamed()).thenReturn(true);
         when(moduleUnderTest.getName()).thenReturn("Bob");
         when(moduleUnderTest.getDescriptor()).thenReturn(descriptor);
     }
@@ -119,6 +120,19 @@ class ExportedPackagesCheckTest {
                                 + "\torg.creek.internal.b"
                                 + System.lineSeparator()
                                 + "]"));
+    }
+
+    @Test
+    void shouldIgnoreUnnamedModules() {
+        // Given:
+        when(moduleUnderTest.isNamed()).thenReturn(false);
+        when(moduleUnderTest.getDescriptor()).thenReturn(null);
+        givenPackages("org.creek.api.a");
+
+        // When:
+        check.check(ctx);
+
+        // Then: did not throw.
     }
 
     @Test


### PR DESCRIPTION
an unnamed modules export all their packages.  So a creek module that is an unnamed module will always fail this test. However, given its already failed the `CheckModule` test, this is superfluous.
