### PR TITLE
Add util for extracting cover coverage agent params

### DIFF
--- a/util/src/main/java/module-info.java
+++ b/util/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module creek.test.util {
     requires transitive creek.base.annotation;
     requires transitive com.github.spotbugs.annotations;
+    requires transitive java.management;
 
     exports org.creek.api.test.util;
 }

--- a/util/src/main/java/module-info.java
+++ b/util/src/main/java/module-info.java
@@ -4,4 +4,5 @@ module creek.test.util {
     requires transitive java.management;
 
     exports org.creek.api.test.util;
+    exports org.creek.api.test.util.coverage;
 }

--- a/util/src/main/java/org/creek/api/test/util/coverage/CodeCoverage.java
+++ b/util/src/main/java/org/creek/api/test/util/coverage/CodeCoverage.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creek.api.test.util.coverage;
+
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.Optional;
+import org.creek.api.base.annotation.VisibleForTesting;
+
+public final class CodeCoverage {
+
+    private CodeCoverage() {}
+
+    /**
+     * Finds the code coverage Java agent command line arg this JVM was started with, if any.
+     *
+     * <p>Useful to set on child processes started by tests to ensure the code they execute is
+     * included in coverage metrics.
+     *
+     * @return the Java agent command line arg, or empty.
+     */
+    public static Optional<String> codeCoverageCmdLineArg() {
+        return codeCoverageCmdLineArg(ManagementFactory.getRuntimeMXBean());
+    }
+
+    @VisibleForTesting
+    static Optional<String> codeCoverageCmdLineArg(final RuntimeMXBean runtimeMXBean) {
+        return runtimeMXBean.getInputArguments().stream()
+                .filter(arg -> arg.startsWith("-javaagent"))
+                .filter(arg -> arg.contains("org.jacoco.agent"))
+                .reduce((first, second) -> first);
+    }
+}

--- a/util/src/test/java/org/creek/api/test/util/coverage/CodeCoverageTest.java
+++ b/util/src/test/java/org/creek/api/test/util/coverage/CodeCoverageTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creek.api.test.util.coverage;
+
+import static org.creek.api.test.util.coverage.CodeCoverage.codeCoverageCmdLineArg;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import java.lang.management.RuntimeMXBean;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CodeCoverageTest {
+
+    @Mock private RuntimeMXBean runtimeMXBean;
+
+    @Test
+    void shouldEmptyIfNotJaCoCoAgentParamPresent() {
+        // Given:
+        when(runtimeMXBean.getInputArguments())
+                .thenReturn(
+                        List.of(
+                                "-javaagent but not Jacoco",
+                                "--javaagent but not org.jacoco.agent"));
+
+        // When:
+        final Optional<String> result = codeCoverageCmdLineArg(runtimeMXBean);
+
+        // Then:
+        assertThat(result, is(Optional.empty()));
+    }
+
+    @Test
+    void shouldReturnJaCoCoAgentParam() {
+        // Given:
+        when(runtimeMXBean.getInputArguments())
+                .thenReturn(List.of("--arg", "-javaagent_blah_org.jacoco.agent_blah", "-arg"));
+
+        // When:
+        final Optional<String> result = codeCoverageCmdLineArg(runtimeMXBean);
+
+        // Then:
+        assertThat(result, is(Optional.of("-javaagent_blah_org.jacoco.agent_blah")));
+    }
+
+    @Test
+    void shouldReturnFirstJaCoCoAgentParam() {
+        // Given:
+        when(runtimeMXBean.getInputArguments())
+                .thenReturn(
+                        List.of(
+                                "-javaagent_first_org.jacoco.agent",
+                                "-javaagent_second_org.jacoco.agent"));
+
+        // When:
+        final Optional<String> result = codeCoverageCmdLineArg(runtimeMXBean);
+
+        // Then:
+        assertThat(result, is(Optional.of("-javaagent_first_org.jacoco.agent")));
+    }
+}


### PR DESCRIPTION
### Description
This is useful when spawning child processes from tests if the code the child process executed should count towards coverage metrics

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended