### PR TITLE
Conformity should accept old and new package roots for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,20 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+registries:
+  creek-github-packages:
+    type: maven-repository
+    url: https://maven.pkg.github.com/creek-service/*
+    username: "Creek-Bot-Token"
+    password: "\u0067hp_LtyvXrQZen3WlKenUhv21Mg6NG38jn0AO2YH"
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-    reviewers:
-      - creek-service/code-reviewers
   - package-ecosystem: gradle
     directory: /
+    registries:
+      - creek-github-packages
     schedule:
       interval: weekly
-    reviewers:
-      - creek-service/code-reviewers

--- a/conformity/src/main/java/org/creek/internal/test/conformity/Constants.java
+++ b/conformity/src/main/java/org/creek/internal/test/conformity/Constants.java
@@ -19,6 +19,8 @@ package org.creek.internal.test.conformity;
 public final class Constants {
     private Constants() {}
 
-    public static final String CREEK_PACKAGE = "org.creek";
+    public static final String CREEK_PACKAGE = "org.creekservice";
+    public static final String OLD_CREEK_PACKAGE = "org.creek";
     public static final String API_PACKAGE = CREEK_PACKAGE + ".api";
+    public static final String OLD_API_PACKAGE = OLD_CREEK_PACKAGE + ".api";
 }

--- a/conformity/src/main/java/org/creek/internal/test/conformity/check/ExportedPackagesCheck.java
+++ b/conformity/src/main/java/org/creek/internal/test/conformity/check/ExportedPackagesCheck.java
@@ -19,6 +19,7 @@ package org.creek.internal.test.conformity.check;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static org.creek.internal.test.conformity.Constants.API_PACKAGE;
+import static org.creek.internal.test.conformity.Constants.OLD_API_PACKAGE;
 
 import java.util.Arrays;
 import java.util.function.Predicate;
@@ -58,7 +59,10 @@ public final class ExportedPackagesCheck implements CheckRunner {
     private void checkApiPackagesExported(final Module moduleUnderTest) {
         final String notExported =
                 sortedFilteredPackages(moduleUnderTest)
-                        .filter(pkg -> pkg.startsWith(API_PACKAGE))
+                        .filter(
+                                pkg ->
+                                        pkg.startsWith(API_PACKAGE)
+                                                || pkg.startsWith(OLD_API_PACKAGE))
                         .filter(pkg -> !moduleUnderTest.isExported(pkg))
                         .collect(joining(NL_INDENT));
 
@@ -70,7 +74,10 @@ public final class ExportedPackagesCheck implements CheckRunner {
     private void checkNonApiPackagesNotExported(final Module moduleUnderTest) {
         final String exported =
                 sortedFilteredPackages(moduleUnderTest)
-                        .filter(pkg -> !pkg.startsWith(API_PACKAGE))
+                        .filter(
+                                pkg ->
+                                        !(pkg.startsWith(API_PACKAGE)
+                                                || pkg.startsWith(OLD_API_PACKAGE)))
                         .filter(moduleUnderTest::isExported)
                         .collect(joining(NL_INDENT));
 

--- a/conformity/src/test/java/org/creek/internal/test/conformity/check/ExportedPackagesCheckTest.java
+++ b/conformity/src/test/java/org/creek/internal/test/conformity/check/ExportedPackagesCheckTest.java
@@ -57,7 +57,7 @@ class ExportedPackagesCheckTest {
     @Test
     void shouldIgnoreNoneApiPackages() {
         // Given:
-        givenPackages("org.creek.other", "not.org.creek");
+        givenPackages("org.creek.other", "not.org.creekservice");
 
         // When:
         check.check(ctx);
@@ -68,8 +68,8 @@ class ExportedPackagesCheckTest {
     @Test
     void shouldPassIfAllApiPackagesAreExportedAndNonApiPackagesAreNot() {
         // Given:
-        givenPackages("org.creek.api.a", "org.creek.api.b", "org.creek.internal.a");
-        givenExportedPackages("org.creek.api.a", "org.creek.api.b");
+        givenPackages("org.creekservice.api.a", "org.creek.api.b", "org.creek.internal.a");
+        givenExportedPackages("org.creekservice.api.a", "org.creek.api.b");
 
         // When:
         check.check(ctx);
@@ -80,7 +80,7 @@ class ExportedPackagesCheckTest {
     @Test
     void shouldThrowOnNonExportedApiPackages() {
         // Given:
-        givenPackages("org.creek.api", "org.creek.api.a", "org.creek.api.b");
+        givenPackages("org.creek.api", "org.creek.api.a", "org.creekservice.api.b");
         givenExportedPackages("org.creek.api.a");
 
         // When:
@@ -94,7 +94,7 @@ class ExportedPackagesCheckTest {
                                 + System.lineSeparator()
                                 + "\torg.creek.api"
                                 + System.lineSeparator()
-                                + "\torg.creek.api.b"
+                                + "\torg.creekservice.api.b"
                                 + System.lineSeparator()
                                 + "]"));
     }
@@ -102,8 +102,8 @@ class ExportedPackagesCheckTest {
     @Test
     void shouldThrowOnNonApiPackageExported() {
         // Given:
-        givenPackages("org.creek.internal", "org.creek.internal.a", "org.creek.internal.b");
-        givenExportedPackages("org.creek.internal.a", "org.creek.internal.b");
+        givenPackages("org.creek.internal", "org.creekservice.internal.a", "org.creek.internal.b");
+        givenExportedPackages("org.creekservice.internal.a", "org.creek.internal.b");
 
         // When:
         final Exception e = assertThrows(RuntimeException.class, () -> check.check(ctx));
@@ -115,9 +115,9 @@ class ExportedPackagesCheckTest {
                         "Non-API packages are exposed (without a 'to' clause) "
                                 + "in the module's module-info.java file. module=Bob, exposed_packages=["
                                 + System.lineSeparator()
-                                + "\torg.creek.internal.a"
-                                + System.lineSeparator()
                                 + "\torg.creek.internal.b"
+                                + System.lineSeparator()
+                                + "\torg.creekservice.internal.a"
                                 + System.lineSeparator()
                                 + "]"));
     }
@@ -127,7 +127,7 @@ class ExportedPackagesCheckTest {
         // Given:
         when(moduleUnderTest.isNamed()).thenReturn(false);
         when(moduleUnderTest.getDescriptor()).thenReturn(null);
-        givenPackages("org.creek.api.a");
+        givenPackages("org.creekservice.api.a");
 
         // When:
         check.check(ctx);
@@ -150,12 +150,12 @@ class ExportedPackagesCheckTest {
     @Test
     void shouldIgnoreExcludedPackages() {
         // Given:
-        givenPackages("org.creek.api.a", "org.creek.api.b.c");
+        givenPackages("org.creekservice.api.a", "org.creek.api.b.c");
 
         check =
                 new ExportedPackagesCheck(
                         new ExportedPackagesCheck.Options()
-                                .excludedPackages("org.creek.api.a", "org.creek.api.b.*"));
+                                .excludedPackages("org.creekservice.api.a", "org.creek.api.b.*"));
 
         // When:
         check.check(ctx);


### PR DESCRIPTION
### Description

Part of https://github.com/creek-service/creek-test/issues/24

While we're going through the process of renaming the root package from `org.creek` to `org.creekservice` the conformity check will need to accept either.

https://github.com/creek-service/creek-test/issues/28 raised to remove the old `org.creek` root package support once done.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended