### PR TITLE
Add `tools: latest` to ensure fix present

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        tools: latest
         
     - name: Set up JDK 11
       uses: actions/setup-java@v3
@@ -48,7 +49,7 @@ jobs:
     - name: Build
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ./gradlew check
+      run: ./gradlew
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
As per https://github.com/github/codeql-action/issues/1040#issuecomment-1120055880, temporarily add the `tools: latest` line to the config to ensure codeQl version is at least 2.9.1

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended