### PR TITLE
Enhance conformity testing: common excludes

### DIFF
--- a/conformity/src/main/java/org/creekservice/api/test/conformity/ConformityTester.java
+++ b/conformity/src/main/java/org/creekservice/api/test/conformity/ConformityTester.java
@@ -25,7 +25,8 @@ import org.creekservice.internal.test.conformity.DefaultConformityTester;
  *
  * <p>See subtypes of {@link ConformityCheck} for details of checks.
  */
-public interface ConformityTester {
+public interface ConformityTester
+        extends ExcludesPackages<ConformityTester>, ExcludesClasses<ConformityTester> {
 
     /**
      * Execute the standard set of conformity checks against the module containing the supplied
@@ -54,16 +55,15 @@ public interface ConformityTester {
      *
      * <pre>{@code
      * ConformityTester.builder(ModuleTest.class)
-     *                 .withCustom("Customizing because ...",
-     *                             CheckExportedPackages.builder().excludedPackages("some.package")
+     *                 .withCustom(CheckExportedPackages.builder()
+     *                 .excludedPackages("Excluded because ...", "some.package")
      *                 .check();
      * }</pre>
      *
-     * @param justification the reason why its being customized.
      * @param check the customized check
      * @return self
      */
-    ConformityTester withCustom(String justification, ConformityCheck check);
+    ConformityTester withCustom(ConformityCheck check);
 
     /**
      * Disable a check.

--- a/conformity/src/main/java/org/creekservice/api/test/conformity/ExcludesClasses.java
+++ b/conformity/src/main/java/org/creekservice/api/test/conformity/ExcludesClasses.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.test.conformity;
+
+/** Common interface for checks that exclude by class. */
+public interface ExcludesClasses<T> {
+
+    /**
+     * Exclude one or more classes from the check
+     *
+     * @param justification text explaining why they are excluded.
+     * @param classes classes to exclude. Subtypes will not be excluded.
+     * @return self.
+     */
+    T withExcludedClasses(String justification, Class<?>... classes);
+
+    /**
+     * Exclude one or more classes from the check
+     *
+     * @param justification text explaining why they are excluded.
+     * @param excludeSubtypes {@code} true if subtypes of the supplied {@code classes} should also
+     *     be excluded
+     * @param classes classes to exclude.
+     * @return self.
+     */
+    T withExcludedClasses(String justification, boolean excludeSubtypes, Class<?>... classes);
+}

--- a/conformity/src/main/java/org/creekservice/api/test/conformity/ExcludesPackages.java
+++ b/conformity/src/main/java/org/creekservice/api/test/conformity/ExcludesPackages.java
@@ -14,21 +14,17 @@
  * limitations under the License.
  */
 
-package org.creekservice;
+package org.creekservice.api.test.conformity;
 
-
-import org.creekservice.api.test.conformity.ConformityTester;
-import org.creekservice.api.test.conformity.test.types.bad.NotExported;
-import org.junit.jupiter.api.Test;
-
-class ModuleTest {
-
-    @Test
-    void shouldConform() {
-        ConformityTester.builder(ModuleTest.class)
-                .withExcludedPackages(
-                        "Package contains test classes that intentionally break checks",
-                        NotExported.class.getPackageName())
-                .check();
-    }
+/** Common interface for checks that exclude by package. */
+public interface ExcludesPackages<T> {
+    /**
+     * Exclude classes in one or more packages from the check
+     *
+     * @param justification text explaining why they are excluded.
+     * @param packageNames packages to exclude. Any name ending in `.*` will also ignore all
+     *     sub-packages.
+     * @return self.
+     */
+    T withExcludedPackages(String justification, String... packageNames);
 }

--- a/conformity/src/main/java/org/creekservice/api/test/conformity/check/CheckConstructorsPrivate.java
+++ b/conformity/src/main/java/org/creekservice/api/test/conformity/check/CheckConstructorsPrivate.java
@@ -17,6 +17,8 @@
 package org.creekservice.api.test.conformity.check;
 
 
+import org.creekservice.api.test.conformity.ExcludesClasses;
+import org.creekservice.api.test.conformity.ExcludesPackages;
 import org.creekservice.internal.test.conformity.check.ConstructorsPrivateCheck;
 
 /**
@@ -25,37 +27,13 @@ import org.creekservice.internal.test.conformity.check.ConstructorsPrivateCheck;
  * <p>The use of factory methods makes it easier in the future to change the type of object
  * returned, allowing for more flexibility when refactoring.
  */
-public interface CheckConstructorsPrivate extends ConformityCheck {
+public interface CheckConstructorsPrivate
+        extends ConformityCheck,
+                ExcludesPackages<CheckConstructorsPrivate>,
+                ExcludesClasses<CheckConstructorsPrivate> {
 
     /** @return a builder used to customise the check */
     static CheckConstructorsPrivate builder() {
         return new ConstructorsPrivateCheck.Options();
     }
-
-    /**
-     * Exclude one or more classes from the check
-     *
-     * @param classes classes to exclude. Subtypes will not be excluded.
-     * @return self.
-     */
-    CheckConstructorsPrivate excludedClasses(Class<?>... classes);
-
-    /**
-     * Exclude one or more classes from the check
-     *
-     * @param excludeSubtypes {@code} true if subtypes of the supplied {@code classes} should also
-     *     be excluded
-     * @param classes classes to exclude.
-     * @return self.
-     */
-    CheckConstructorsPrivate excludedClasses(boolean excludeSubtypes, Class<?>... classes);
-
-    /**
-     * Exclude classes in one or more packages from the check
-     *
-     * @param packageNames packages to exclude. Any name ending in `.*` will also ignore all
-     *     sub-packages.
-     * @return self.
-     */
-    CheckConstructorsPrivate excludedPackages(String... packageNames);
 }

--- a/conformity/src/main/java/org/creekservice/api/test/conformity/check/CheckExportedPackages.java
+++ b/conformity/src/main/java/org/creekservice/api/test/conformity/check/CheckExportedPackages.java
@@ -17,6 +17,7 @@
 package org.creekservice.api.test.conformity.check;
 
 
+import org.creekservice.api.test.conformity.ExcludesPackages;
 import org.creekservice.internal.test.conformity.check.ExportedPackagesCheck;
 
 /**
@@ -25,19 +26,11 @@ import org.creekservice.internal.test.conformity.check.ExportedPackagesCheck;
  *
  * <p>Note, non-API packages can be exported <i>to</i> specific modules, e.g. other Creek modules.
  */
-public interface CheckExportedPackages extends ConformityCheck {
+public interface CheckExportedPackages
+        extends ConformityCheck, ExcludesPackages<CheckExportedPackages> {
 
     /** @return a builder used to customise the check */
     static CheckExportedPackages builder() {
         return new ExportedPackagesCheck.Options();
     }
-
-    /**
-     * Exclude one or more packages from the check
-     *
-     * @param packageNames packages to exclude. Any name ending in `.*` will ignore all sub-packages
-     *     too.
-     * @return self.
-     */
-    CheckExportedPackages excludedPackages(String... packageNames);
 }

--- a/conformity/src/main/java/org/creekservice/internal/test/conformity/check/ConstructorsPrivateCheck.java
+++ b/conformity/src/main/java/org/creekservice/internal/test/conformity/check/ConstructorsPrivateCheck.java
@@ -80,18 +80,29 @@ public final class ConstructorsPrivateCheck implements CheckRunner {
         private final PackageFilter.Builder packageFilter = PackageFilter.builder();
 
         @Override
-        public Options excludedClasses(final Class<?>... classes) {
-            return excludedClasses(false, classes);
+        public Options withExcludedClasses(final String justification, final Class<?>... classes) {
+            return withExcludedClasses(justification, false, classes);
         }
 
         @Override
-        public Options excludedClasses(final boolean excludeSubtypes, final Class<?>... classes) {
+        public Options withExcludedClasses(
+                final String justification,
+                final boolean excludeSubtypes,
+                final Class<?>... classes) {
+            if (justification.isBlank()) {
+                throw new IllegalArgumentException("justification can not be blank.");
+            }
+
             Arrays.stream(classes).forEach(c -> classFilter.addExclude(c, excludeSubtypes));
             return this;
         }
 
         @Override
-        public Options excludedPackages(final String... packageNames) {
+        public Options withExcludedPackages(
+                final String justification, final String... packageNames) {
+            if (justification.isBlank()) {
+                throw new IllegalArgumentException("justification can not be blank.");
+            }
             Arrays.stream(packageNames).forEach(packageFilter::addExclude);
             return this;
         }

--- a/conformity/src/test/java/org/creekservice/internal/test/conformity/DefaultConformityTesterTest.java
+++ b/conformity/src/test/java/org/creekservice/internal/test/conformity/DefaultConformityTesterTest.java
@@ -35,16 +35,9 @@ class DefaultConformityTesterTest {
     @Test
     void shouldPassIfEverythingIsOk() {
         ConformityTester.builder(ConformityTester.class)
-                .withCustom(
+                .withExcludedPackages(
                         "deliberately bad test classes",
-                        CheckExportedPackages.builder()
-                                .excludedPackages(
-                                        "org.creekservice.api.test.conformity.test.types.bad"))
-                .withCustom(
-                        "deliberately bad test classes",
-                        CheckConstructorsPrivate.builder()
-                                .excludedPackages(
-                                        "org.creekservice.api.test.conformity.test.types.bad"))
+                        "org.creekservice.api.test.conformity.test.types.bad")
                 .check();
     }
 
@@ -88,13 +81,15 @@ class DefaultConformityTesterTest {
         final ConformityTester tester =
                 ConformityTester.builder(ConformityTester.class)
                         .withCustom(
-                                "to test customising",
                                 CheckExportedPackages.builder()
-                                        .excludedPackages(NotExported.class.getPackageName()))
+                                        .withExcludedPackages(
+                                                "to test customising",
+                                                NotExported.class.getPackageName()))
                         .withCustom(
-                                "todo",
                                 CheckConstructorsPrivate.builder()
-                                        .excludedPackages(NotExported.class.getPackageName()));
+                                        .withExcludedPackages(
+                                                "to test customising",
+                                                NotExported.class.getPackageName()));
 
         // When:
         tester.check();
@@ -142,25 +137,10 @@ class DefaultConformityTesterTest {
 
         // When:
         final Exception e =
-                assertThrows(IllegalStateException.class, () -> tester.withCustom("cos", check));
+                assertThrows(IllegalStateException.class, () -> tester.withCustom(check));
 
         // Then:
         assertThat(e.getMessage(), startsWith("Unsupported check"));
-    }
-
-    @Test
-    void shouldThrownWhenCustomisingIfNoJustification() {
-        // Given:
-        final ConformityTester tester = ConformityTester.builder(EqualsTester.class);
-
-        // When:
-        final Exception e =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> tester.withCustom(" ", CheckModule.builder()));
-
-        // Then:
-        assertThat(e.getMessage(), startsWith("justification can not be blank"));
     }
 
     @Test

--- a/conformity/src/test/java/org/creekservice/internal/test/conformity/DefaultConformityTesterTest.java
+++ b/conformity/src/test/java/org/creekservice/internal/test/conformity/DefaultConformityTesterTest.java
@@ -28,6 +28,8 @@ import org.creekservice.api.test.conformity.check.CheckExportedPackages;
 import org.creekservice.api.test.conformity.check.CheckModule;
 import org.creekservice.api.test.conformity.check.ConformityCheck;
 import org.creekservice.api.test.conformity.test.types.bad.NotExported;
+import org.creekservice.api.test.conformity.test.types.bad.PublicTypeWithImplicitPublicConstructor;
+import org.creekservice.api.test.conformity.test.types.bad.PublicTypeWithPublicConstructor;
 import org.junit.jupiter.api.Test;
 
 class DefaultConformityTesterTest {
@@ -83,13 +85,12 @@ class DefaultConformityTesterTest {
                         .withCustom(
                                 CheckExportedPackages.builder()
                                         .withExcludedPackages(
-                                                "to test customising",
-                                                NotExported.class.getPackageName()))
-                        .withCustom(
-                                CheckConstructorsPrivate.builder()
-                                        .withExcludedPackages(
-                                                "to test customising",
-                                                NotExported.class.getPackageName()));
+                                                "testing", NotExported.class.getPackageName()))
+                        .withExcludedClasses(
+                                "testing",
+                                NotExported.class,
+                                PublicTypeWithImplicitPublicConstructor.class,
+                                PublicTypeWithPublicConstructor.class);
 
         // When:
         tester.check();

--- a/conformity/src/test/java/org/creekservice/internal/test/conformity/DefaultConformityTesterTest.java
+++ b/conformity/src/test/java/org/creekservice/internal/test/conformity/DefaultConformityTesterTest.java
@@ -28,6 +28,7 @@ import org.creekservice.api.test.conformity.check.CheckExportedPackages;
 import org.creekservice.api.test.conformity.check.CheckModule;
 import org.creekservice.api.test.conformity.check.ConformityCheck;
 import org.creekservice.api.test.conformity.test.types.bad.NotExported;
+import org.creekservice.api.test.conformity.test.types.bad.PublicSubTypeWithPublicConstructor;
 import org.creekservice.api.test.conformity.test.types.bad.PublicTypeWithImplicitPublicConstructor;
 import org.creekservice.api.test.conformity.test.types.bad.PublicTypeWithPublicConstructor;
 import org.junit.jupiter.api.Test;
@@ -89,6 +90,7 @@ class DefaultConformityTesterTest {
                         .withExcludedClasses(
                                 "testing",
                                 NotExported.class,
+                                PublicSubTypeWithPublicConstructor.class,
                                 PublicTypeWithImplicitPublicConstructor.class,
                                 PublicTypeWithPublicConstructor.class);
 

--- a/conformity/src/test/java/org/creekservice/internal/test/conformity/check/ConstructorsPrivateCheckTest.java
+++ b/conformity/src/test/java/org/creekservice/internal/test/conformity/check/ConstructorsPrivateCheckTest.java
@@ -26,6 +26,7 @@ import org.creekservice.api.test.conformity.test.types.bad.PublicSubTypeWithPubl
 import org.creekservice.api.test.conformity.test.types.bad.PublicTypeWithImplicitPublicConstructor;
 import org.creekservice.api.test.conformity.test.types.bad.PublicTypeWithPublicConstructor;
 import org.creekservice.internal.test.conformity.CheckTarget;
+import org.creekservice.internal.test.conformity.check.ConstructorsPrivateCheck.Options;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,7 +49,7 @@ class ConstructorsPrivateCheckTest {
 
     @BeforeEach
     void setUp() {
-        check = new ConstructorsPrivateCheck(new ConstructorsPrivateCheck.Options());
+        check = new ConstructorsPrivateCheck(new Options());
     }
 
     @Test
@@ -109,8 +110,9 @@ class ConstructorsPrivateCheckTest {
         // Given:
         check =
                 new ConstructorsPrivateCheck(
-                        new ConstructorsPrivateCheck.Options()
-                                .excludedPackages(
+                        new Options()
+                                .withExcludedPackages(
+                                        "testing",
                                         PublicSubTypeWithPublicConstructor.class.getPackageName()));
 
         // When:
@@ -124,8 +126,9 @@ class ConstructorsPrivateCheckTest {
         // Given:
         check =
                 new ConstructorsPrivateCheck(
-                        new ConstructorsPrivateCheck.Options()
-                                .excludedClasses(
+                        new Options()
+                                .withExcludedClasses(
+                                        "testing",
                                         PublicTypeWithPublicConstructor.class,
                                         PublicTypeWithImplicitPublicConstructor.class,
                                         PublicSubTypeWithPublicConstructor.class));
@@ -141,8 +144,9 @@ class ConstructorsPrivateCheckTest {
         // Given:
         check =
                 new ConstructorsPrivateCheck(
-                        new ConstructorsPrivateCheck.Options()
-                                .excludedClasses(
+                        new Options()
+                                .withExcludedClasses(
+                                        "testing",
                                         true,
                                         PublicTypeWithPublicConstructor.class,
                                         PublicTypeWithImplicitPublicConstructor.class));
@@ -151,5 +155,35 @@ class ConstructorsPrivateCheckTest {
         check.check(target);
 
         // Then: did not fail.
+    }
+
+    @Test
+    void shouldThrownOnEmptyPackageJustification() {
+        // Given:
+        final Options options = new Options();
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> options.withExcludedPackages(" ", "org.creekservice.api.a"));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("justification can not be blank"));
+    }
+
+    @Test
+    void shouldThrownOnEmptyClassJustification() {
+        // Given:
+        final Options options = new Options();
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> options.withExcludedClasses(" ", getClass()));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("justification can not be blank"));
     }
 }

--- a/conformity/src/test/java/org/creekservice/internal/test/conformity/check/ExportedPackagesCheckTest.java
+++ b/conformity/src/test/java/org/creekservice/internal/test/conformity/check/ExportedPackagesCheckTest.java
@@ -19,6 +19,7 @@ package org.creekservice.internal.test.conformity.check;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +28,7 @@ import java.util.Arrays;
 import java.util.Set;
 import org.creekservice.api.test.conformity.test.types.bad.NotExported;
 import org.creekservice.internal.test.conformity.CheckTarget;
+import org.creekservice.internal.test.conformity.check.ExportedPackagesCheck.Options;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,7 +48,7 @@ class ExportedPackagesCheckTest {
 
     @BeforeEach
     void setUp() {
-        check = new ExportedPackagesCheck(new ExportedPackagesCheck.Options());
+        check = new ExportedPackagesCheck(new Options());
 
         when(ctx.moduleUnderTest()).thenReturn(moduleUnderTest);
         when(moduleUnderTest.isNamed()).thenReturn(true);
@@ -158,9 +160,11 @@ class ExportedPackagesCheckTest {
 
         check =
                 new ExportedPackagesCheck(
-                        new ExportedPackagesCheck.Options()
-                                .excludedPackages(
-                                        "org.creekservice.api.a", "org.creekservice.api.b.*"));
+                        new Options()
+                                .withExcludedPackages(
+                                        "testing",
+                                        "org.creekservice.api.a",
+                                        "org.creekservice.api.b.*"));
 
         // When:
         check.check(ctx);
@@ -186,6 +190,21 @@ class ExportedPackagesCheckTest {
                                 + "\torg.creekservice.api.test.conformity.test.types.bad"
                                 + System.lineSeparator()
                                 + "]"));
+    }
+
+    @Test
+    void shouldThrownOnEmptyJustification() {
+        // Given:
+        final Options options = new Options();
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> options.withExcludedPackages(" ", "org.creekservice.api.a"));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("justification can not be blank"));
     }
 
     private void givenPackages(final String... packageNames) {

--- a/test-unnamed/src/test/java/org/creekservice/ModuleTest.java
+++ b/test-unnamed/src/test/java/org/creekservice/ModuleTest.java
@@ -53,9 +53,10 @@ class ModuleTest {
         ConformityTester.builder(ModuleTest.class)
                 .withDisabled("not a module", CheckModule.builder())
                 .withCustom(
-                        "deliberately bad type",
                         CheckConstructorsPrivate.builder()
-                                .excludedClasses(ApiTypeWithPublicConstructor.class))
+                                .withExcludedClasses(
+                                        "deliberately bad type",
+                                        ApiTypeWithPublicConstructor.class))
                 .check();
     }
 }


### PR DESCRIPTION
Enhance conformity testing to allow classes and packages to be excluded with one call from all checks that support such exclusions.

So:

```java
ConformityTester.builder(ModuleTest.class)
   .withCustom(
      "Package contains test classes that intentionally break checks",
      CheckExportedPackages.builder()
         .excludedPackages(NotExported.class.getPackageName()))
   .withCustom(
      "Package contains test classes that intentionally break checks",
      CheckConstructorsPrivate.builder()
         .excludedPackages(NotExported.class.getPackageName()))
   .check();
```

...becomes...

```java
ConformityTester.builder(ModuleTest.class)
   .withExcludedPackages(
      "Package contains test classes that intentionally break checks",
      NotExported.class.getPackageName())
   .check();
```

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended