### PR TITLE
Conformity: only test code with non-module Jar.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,10 +44,10 @@ allprojects {
 
 subprojects {
     apply(plugin = "maven-publish")
+    apply(plugin = "jacoco")
 
     if (!name.startsWith("test-")) {
         apply(plugin = "org.javamodularity.moduleplugin")
-        apply(plugin = "jacoco")
     }
 
     project.version = project.parent?.version!!

--- a/conformity/README.md
+++ b/conformity/README.md
@@ -2,7 +2,7 @@
 
 Provides test helpers for checking Creek's own modules and code conform to certain standards.
 
-## Conformity testing
+## Adding conformity testing
 
 Each module for conformity can be tested by adding a single test class utilising [`ConformityTester`][1]
 
@@ -23,6 +23,25 @@ class ModuleTest {
 
 For a list of checks, refer to the javadocs of [`ConformityCheck`][2] subtypes.
 
+### Disabling checks:
+
+Individual checks can be disabled. For example, if not testing a Java module you will need to disable the module test:
+
+```java
+class ModuleTest {
+    @Test
+    void shouldConform() {
+        ConformityTester.builder(ModuleTest.class)
+                .withDisabled(
+                        "Does not run under JPMS",
+                        CheckModule.builder())
+                .check();
+    }
+}
+```
+
+### Customising checks
+
 Some checks can be customised. See javadocs of [`ConformityCheck.Builder`][2] subtypes. For example:
 
 ```java
@@ -39,7 +58,100 @@ class ModuleTest {
         ConformityTester.builder(ModuleTest.class)
                 .withCustom(
                         CheckApiPackagesExposed.builder()
-                                .excludedPackages("some.package.name.to.exclude.*"))
+                                .excludedPackages(
+                                        "justification on why they are excluded",
+                                        "exact.package.to.exclude",
+                                        "base.package.to.exclude.*"))
+                .check();
+    }
+}
+```
+
+It is also possible to exclude types & packages across all checks that support such customisation. For example:
+
+```java
+package org.creekservice;
+
+import org.creekservice.api.test.conformity.ConformityTester;
+import org.creekservice.api.test.conformity.check.CheckExportedPackages;
+import org.junit.jupiter.api.Test;
+
+class ModuleTest {
+
+    @Test
+    void shouldConform() {
+        ConformityTester.builder(ModuleTest.class)
+                .withExcludedPackages(
+                        "justification on why they are excluded",
+                        "package.a", "package.b.*")
+                .withExcludedClasses(
+                        "justification on why they are excluded",
+                        Foo.class, Bar.class)
+                .withExcludedClassPattern(
+                        "justification on why they are excluded",
+                        ".*Mock.*")
+                .check();
+    }
+}
+```
+
+### Including test code
+
+Any class ending in `Test`, or nested within such a class, is excluded by default. This is to avoid any test classes
+that have been monkey patched into a module from causing conformity checks to fail.  However, it is possible to disable
+this filter. This can be useful if a) the jar under test is not a Java Module, or b) there are production classes that
+end with `Test` and a more specific filter is required.
+
+```java
+package org.creekservice;
+
+import org.creekservice.api.test.conformity.ConformityTester;
+import org.creekservice.api.test.conformity.check.CheckExportedPackages;
+import org.junit.jupiter.api.Test;
+
+class ModuleTest {
+
+    @Test
+    void shouldConform() {
+        ConformityTester.builder(ModuleTest.class)
+                .withoutExcludedTestClassPattern("justification: as an example in the docs")
+                .withExcludedClassPattern("test files", ".*ActualTest")
+                .check();
+    }
+}
+```
+
+### Testing Old School Jars
+
+The norm is to test Creek jars under JPMS as Java Modules. However, some jars, e.g. Gradle plugins, aren't.
+Conformity testing outside JPMS requires a little extra setup to run the tests from the compiled jar, which allows
+the tests to restrict the conformity testing to only the types in the jar, and not in dependencies.
+
+Add the following to the project's `build.gradle.kts` to have the tests run with a compiled jar:
+
+```kotlin
+tasks.test {
+    // As not a module, need to compliance check the actual jar:
+    dependsOn("jar")
+    classpath = files(tasks.jar.get().archiveFile, project.sourceSets.test.get().output, configurations.testRuntimeClasspath)
+}
+```
+
+and ensure the type passed to the conformity tester is from the jar and not a test type:
+
+```java
+package org.creekservice;
+
+import org.creekservice.api.test.conformity.ConformityTester;
+import org.creekservice.api.test.conformity.check.CheckExportedPackages;
+import org.junit.jupiter.api.Test;
+
+class ModuleTest {
+    @Test
+    void shouldPassConformityFromUnnamedModule() {
+        ConformityTester.builder(TypeFromTheProductionCode.class)
+                .withDisabled("not a module", CheckModule.builder())
+                .withoutExcludedTestClassPattern("not a module: test types are not in the jar")
                 .check();
     }
 }

--- a/conformity/src/main/java/org/creekservice/internal/test/conformity/CheckTarget.java
+++ b/conformity/src/main/java/org/creekservice/internal/test/conformity/CheckTarget.java
@@ -25,10 +25,12 @@ public final class CheckTarget implements AutoCloseable {
 
     private final URI location;
     private final Module moduleUnderTest;
+    private final Class<?> typeFromModuleToTest;
     private final AtomicReference<ClassFinder> types;
 
     public CheckTarget(final Class<?> typeFromModuleToTest) {
-        this.location = location(requireNonNull(typeFromModuleToTest, "typeFromModuleToTest"));
+        this.typeFromModuleToTest = requireNonNull(typeFromModuleToTest, "typeFromModuleToTest");
+        this.location = location(typeFromModuleToTest);
         this.moduleUnderTest = typeFromModuleToTest.getModule();
         this.types = new AtomicReference<>();
     }
@@ -43,7 +45,7 @@ public final class CheckTarget implements AutoCloseable {
 
     public ModuleTypes types() {
         return types.updateAndGet(
-                existing -> existing == null ? new ClassFinder(moduleUnderTest) : existing);
+                existing -> existing == null ? new ClassFinder(typeFromModuleToTest) : existing);
     }
 
     @Override

--- a/conformity/src/test/java/org/creekservice/internal/test/conformity/ClassFinderTest.java
+++ b/conformity/src/test/java/org/creekservice/internal/test/conformity/ClassFinderTest.java
@@ -31,7 +31,7 @@ class ClassFinderTest {
 
     @BeforeAll
     static void setUp() {
-        finder = new ClassFinder(ClassFinderTest.class.getModule());
+        finder = new ClassFinder(ClassFinderTest.class);
     }
 
     @AfterAll

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,5 +4,6 @@ include(
     "util",
     "hamcrest",
     "conformity",
-    "test-unnamed"
+    "test-unnamed",
+    "test-unnamed2"
 )

--- a/test-unnamed/src/test/java/org/creekservice/ModuleTest.java
+++ b/test-unnamed/src/test/java/org/creekservice/ModuleTest.java
@@ -49,6 +49,24 @@ class ModuleTest {
     }
 
     @Test
+    void shouldFailIfNonModuleTypeNotFromJar() {
+        // Given:
+        final ConformityTester tester =
+                ConformityTester.builder(ModuleTest.class)
+                        .withDisabled("not a module", CheckModule.builder());
+
+        // When:
+        final Error e = assertThrows(AssertionError.class, tester::check);
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                containsString(
+                        "Code location not a jar file. "
+                                + "See: https://github.com/creek-service/creek-test/tree/main/conformity#testing-old-school-jars"));
+    }
+
+    @Test
     void shouldPassConformityFromUnnamedModule() {
         ConformityTester.builder(ApiTypeWithPublicConstructor.class)
                 .withDisabled("not a module", CheckModule.builder())

--- a/test-unnamed2/build.gradle.kts
+++ b/test-unnamed2/build.gradle.kts
@@ -20,6 +20,9 @@ plugins {
 
 dependencies {
     testImplementation(project(":conformity"))
+    // Depend on unnamed, which brings in bad types
+    //   but that does not mean this module's conformity checks should fail.
+    testImplementation(project(":test-unnamed"))
 }
 
 tasks.test {

--- a/test-unnamed2/src/main/java/org/creekservice/api/unnamed/DifferentBadlyWrittenApiType.java
+++ b/test-unnamed2/src/main/java/org/creekservice/api/unnamed/DifferentBadlyWrittenApiType.java
@@ -14,16 +14,7 @@
  * limitations under the License.
  */
 
-plugins {
-    `java-library`
-}
+package org.creekservice.api.unnamed;
 
-dependencies {
-    testImplementation(project(":conformity"))
-}
-
-tasks.test {
-    // As not a module, need to compliance check the actual jar:
-    dependsOn("jar")
-    classpath = files(tasks.jar.get().archiveFile, project.sourceSets.test.get().output, configurations.testRuntimeClasspath)
-}
+// Has public constructor...
+public final class DifferentBadlyWrittenApiType {}

--- a/test-unnamed2/src/test/java/org/creekservice/ModuleTest.java
+++ b/test-unnamed2/src/test/java/org/creekservice/ModuleTest.java
@@ -22,41 +22,37 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.creekservice.api.test.conformity.ConformityTester;
-import org.creekservice.api.test.conformity.check.CheckConstructorsPrivate;
 import org.creekservice.api.test.conformity.check.CheckModule;
-import org.creekservice.api.unnamed.ApiTypeWithPublicConstructor;
+import org.creekservice.api.unnamed.DifferentBadlyWrittenApiType;
 import org.junit.jupiter.api.Test;
 
 class ModuleTest {
 
     @Test
     void shouldBeUnnamed() {
-        assertThat(ApiTypeWithPublicConstructor.class.getModule().isNamed(), is(false));
+        assertThat(DifferentBadlyWrittenApiType.class.getModule().isNamed(), is(false));
     }
 
     @Test
     void shouldFailOnBadTypes() {
         // Given:
         final ConformityTester tester =
-                ConformityTester.builder(ApiTypeWithPublicConstructor.class)
+                ConformityTester.builder(DifferentBadlyWrittenApiType.class)
                         .withDisabled("not a module", CheckModule.builder());
 
         // When:
         final Error e = assertThrows(AssertionError.class, tester::check);
 
         // Then:
-        assertThat(e.getMessage(), containsString(ApiTypeWithPublicConstructor.class.getName()));
+        assertThat(e.getMessage(), containsString(DifferentBadlyWrittenApiType.class.getName()));
     }
 
     @Test
     void shouldPassConformityFromUnnamedModule() {
-        ConformityTester.builder(ApiTypeWithPublicConstructor.class)
+        // Importantly, this test should not fail due to types imported from test-unnamed:
+        ConformityTester.builder(DifferentBadlyWrittenApiType.class)
                 .withDisabled("not a module", CheckModule.builder())
-                .withCustom(
-                        CheckConstructorsPrivate.builder()
-                                .withExcludedClasses(
-                                        "deliberately bad type",
-                                        ApiTypeWithPublicConstructor.class))
+                .withExcludedClasses("Intentionally bad", DifferentBadlyWrittenApiType.class)
                 .check();
     }
 }


### PR DESCRIPTION
The conformity testing was using the module name to limit what types where tested. For jars that do not run under JPMS this meant types inherited from dependencies were also being tested.  This is inefficient and incorrect.  The tests now use the jar file name. This requires a few setup changes, which are documented.

### Reviewer checklist
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [x] Ensure any appropriate documentation has been added or amended