### PR TITLE
Quieten non-Creek code in tests

### DIFF
--- a/util/src/main/resources/log4j2.xml
+++ b/util/src/main/resources/log4j2.xml
@@ -18,17 +18,21 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%m%n"/>
+            <PatternLayout pattern="%-5level %logger{36} %m%n"/>
             <ThresholdFilter level="ERROR" onMatch="DENY" onMismatch="ACCEPT"/>
         </Console>
         <Console name="Console_Error" target="SYSTEM_ERR">
-            <PatternLayout pattern="%m%n"/>
+            <PatternLayout pattern="%-5level %logger{36} %m%n"/>
             <ThresholdFilter level="ERROR" onMatch="ACCEPT" onMismatch="DENY"/>
         </Console>
     </Appenders>
 
     <Loggers>
-        <Root level="DEBUG">
+        <Logger name="org.creekservice" level="DEBUG" additivity="false">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="Console_Error"/>
+        </Logger>
+        <Root level="INFO">
             <AppenderRef ref="Console"/>
             <AppenderRef ref="Console_Error"/>
         </Root>


### PR DESCRIPTION
Docker client spams the logs at debug level, so lets keep creek code at debug and everything else at info.

Also renamed file to allow downstream projects the ability to override the LOG4J config in this repo with their own by naming it `log4j2-test.xml`.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended