### PR TITLE
Allow record types in APIs

### DIFF
--- a/conformity/src/main/java/org/creekservice/internal/test/conformity/check/ConstructorsPrivateCheck.java
+++ b/conformity/src/main/java/org/creekservice/internal/test/conformity/check/ConstructorsPrivateCheck.java
@@ -58,6 +58,7 @@ public final class ConstructorsPrivateCheck implements CheckRunner {
                 target.types()
                         .apiClasses()
                         .filter(ClassInfo::isPublic)
+                        .filter(ci -> !ci.isRecord())
                         .filter(ci -> packageFilter.notExcluded(ci.getPackageName()))
                         .filter(ci -> classFilter.notExcluded(ci.loadClass()))
                         .filter(ci -> classPatternFilter.notExcluded(ci.loadClass()))

--- a/conformity/src/test/java/org/creekservice/api/test/conformity/test/types/bad/PublicRecord.java
+++ b/conformity/src/test/java/org/creekservice/api/test/conformity/test/types/bad/PublicRecord.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.test.conformity.test.types.bad;
+
+/**
+ * A record type in the public API.
+ *
+ * <p>Record types <i>must</i> have a public constructor. Therefore, their constructor does
+ * <i>not</i> cause a conformity failure.
+ *
+ * @param someValue some value
+ */
+public record PublicRecord(int someValue) {}

--- a/conformity/src/test/java/org/creekservice/api/test/conformity/test/types/bad/TypeWithNestedRecord.java
+++ b/conformity/src/test/java/org/creekservice/api/test/conformity/test/types/bad/TypeWithNestedRecord.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.test.conformity.test.types.bad;
+
+public final class TypeWithNestedRecord {
+
+    private TypeWithNestedRecord() {}
+
+    /**
+     * A nested record type in the public API.
+     *
+     * <p>Record types <i>must</i> have a public constructor. Therefore, their constructor does
+     * <i>not</i> cause a conformity failure.
+     *
+     * @param s some value
+     */
+    public record NestedRecord(String s) {}
+}


### PR DESCRIPTION
Now that Java 17 is supported, `record` types can be part of the public API. Such types _must_ have a public constructor, which would fail conformity checks.

Record types are just too handy to exclude from APIs, though they should be used carefully as they are _not_ evolvable.

Conformity checks now allow records.
