### PR TITLE
fix(deps): revert classgraph to 4.8.184

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ subprojects {
         // Avoid Creek dependencies as it causes circular dependencies that make releasing tricky...
 
         set("spotBugsVersion", "4.10.3")         // https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-annotations
-        set("classGraphVersion", "4.8.186")     // https://mvnrepository.com/artifact/io.github.classgraph/classgraph
+        set("classGraphVersion", "4.8.184")     // https://mvnrepository.com/artifact/io.github.classgraph/classgraph
 
         set("log4jVersion", "2.26.1")           // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
         set("guavaVersion", "33.6.0-jre")         // https://mvnrepository.com/artifact/com.google.guava/guava


### PR DESCRIPTION
## Summary

- Reverts classgraph from 4.8.186 to 4.8.184
- classgraph 4.8.186 changed wildcard semantics in `acceptPackages()`: `*` now matches a single package segment instead of spanning multiple segments
- This breaks `creek-base`'s `GeneratesSchemas.Scanner` which uses mid-package wildcards like `"org.creekservice.*.schema"`
- Reverting until creek-base is updated to handle the new semantics

## Details

| Pattern | Target package | Old (4.8.184) | New (4.8.186) | Why |
|---------|---------------|:---:|:---:|-----|
| `org.creekservice.*.schema` | `org.creekservice.api.base.schema` | match | no match | `*` can't span `api.base` (2 segments) |
| `*.api.*` | `org.creekservice.api.base.test.module` | match | no match | first `*` can't span `org.creekservice` (2 segments) |

See: https://github.com/classgraph/classgraph/issues/870 and https://github.com/classgraph/classgraph/issues/940

## Test plan

- [ ] creek-test CI passes
- [ ] creek-base trunk build passes after new snapshot published

🤖 Generated with [Claude Code](https://claude.com/claude-code)